### PR TITLE
Fix libraryR call on attach

### DIFF
--- a/RRLab/R/libraryR.R
+++ b/RRLab/R/libraryR.R
@@ -12,6 +12,10 @@
 #' # Also works with unquoted names (non-standard evaluation)
 #' libraryR(dplyr)
 #'
+#' # Package names can also be stored in a vector
+#' pkgs <- c("ggplot2", "dplyr")
+#' libraryR(pkgs)
+#'
 #' @export
 libraryR = function(pkg) {
   if (!requireNamespace("cli", quietly = TRUE)) install.packages("cli", quiet = TRUE)

--- a/RRLab/R/zzz.R
+++ b/RRLab/R/zzz.R
@@ -31,7 +31,7 @@
                         "foreach", "doParallel", "parallel", "progress",
                         "data.table", "splitstackshape")
 
-  RRLab::libraryR(s_requiredpackages)
+  RRLab::libraryR(c(s_requiredpackages))
 
 
 }

--- a/RRLab/man/libraryR.Rd
+++ b/RRLab/man/libraryR.Rd
@@ -23,4 +23,8 @@ libraryR(c("limma", "missMethyl"))
 # Also works with unquoted names (non-standard evaluation)
 libraryR(dplyr)
 
+# Package names can also be stored in a vector
+pkgs <- c("ggplot2", "dplyr")
+libraryR(pkgs)
+
 }


### PR DESCRIPTION
## Summary
- ensure `s_requiredpackages` is evaluated as a vector when loading
- document how to supply a vector of package names to `libraryR`

## Testing
- `Rscript -e "source('RRLab/R/libraryR.R'); s_requiredpackages <- c('stats'); libraryR(s_requiredpackages)"`
- `Rscript -e "source('RRLab/R/libraryR.R'); s_requiredpackages <- c('stats'); libraryR(c(s_requiredpackages))"`

------
https://chatgpt.com/codex/tasks/task_e_68401b0344a483299bd796215813a488