### PR TITLE
Add tests for libraryR

### DIFF
--- a/RRLab/R/libraryR.R
+++ b/RRLab/R/libraryR.R
@@ -28,8 +28,16 @@ libraryR = function(pkg) {
     invisible(capture.output(suppressMessages(suppressWarnings(try(expr, silent = TRUE))), type = "output"))
   }
   
-  pkg = substitute(pkg)
-  pkg = if (is.name(pkg)) as.character(pkg) else eval(pkg, parent.frame())
+  pkg_expr <- substitute(pkg)
+  pkg_val <- tryCatch(eval(pkg_expr, parent.frame()), error = function(e) NULL)
+
+  if (is.character(pkg_val)) {
+    pkg <- pkg_val
+  } else if (is.name(pkg_expr)) {
+    pkg <- as.character(pkg_expr)
+  } else {
+    pkg <- pkg_val
+  }
   
   results = setNames(logical(length(pkg)), pkg)
   

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,4 @@
+## Load libraryR from the package source tree
+## Assume tests are run from within 'tests/testthat'
+## Tests are run from tests/testthat, so go two levels up to package root
+source(file.path('..', '..', 'RRLab', 'R', 'libraryR.R'), local = TRUE)

--- a/tests/testthat/test-libraryR.R
+++ b/tests/testthat/test-libraryR.R
@@ -1,0 +1,34 @@
+library(testthat)
+
+skip_if_not_installed("cli")
+skip_if_not_installed("rlang")
+
+# Ensure libraryR function is loaded via helper.R
+
+
+test_that("libraryR loads quoted package names", {
+  res <- libraryR("stats")
+  expect_named(res, "stats")
+  expect_true(res[["stats"]])
+})
+
+test_that("libraryR loads unquoted package names", {
+  res <- libraryR(stats)
+  expect_named(res, "stats")
+  expect_true(res[["stats"]])
+})
+
+
+test_that("libraryR can load multiple packages", {
+  pkgs <- c("stats", "utils")
+  res <- libraryR(pkgs)
+  expect_equal(names(res), pkgs)
+  expect_true(all(res))
+})
+
+test_that("libraryR returns FALSE for missing packages", {
+  pkg <- "nonexistentPkg12345"
+  res <- libraryR(pkg)
+  expect_named(res, pkg)
+  expect_false(res[[pkg]])
+})


### PR DESCRIPTION
## Summary
- add testthat helper
- add libraryR tests for base package loading and nonexistent packages
- fix helper path to source libraryR correctly
- improve evaluation of `libraryR` argument to handle character vectors

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_6841aa09e7b4832994c08b0dee784a35